### PR TITLE
Remove i5k specific info from email templates

### DIFF
--- a/includes/tripal_chado_datasets.admin.inc
+++ b/includes/tripal_chado_datasets.admin.inc
@@ -134,7 +134,8 @@ function tripal_chado_datasets_organism_approval($form, &$form_state, $id) {
 /**
  * @hook_form_submit()
  *
- * @sends an email to user regarding login credentials to the web apollo site.
+ * Lets users know that their project request was approved (IE the chado organism was created and they can not submit a Chado analysis request).
+ *
  */
 function tripal_chado_datasets_organism_approval_submit($form, &$form_state) {
   $values = $form_state['values']['datasets_table'];
@@ -157,7 +158,7 @@ function tripal_chado_datasets_organism_approval_submit($form, &$form_state) {
       ->fields(['status' => $status])
       ->condition('id', $id, '=')
       ->execute();
-    //   Send email to the user about the login credentials to the web apollo site
+
     $user_email_sent = drupal_mail('tripal_chado_datasets', 'request_project_approved_email', $to, language_default(), $values, $from, TRUE);
 
     // $is_species_exists = db_select('chado.organism', 'o')->fields('o', array('organism_id'))->condition('o.genus', $genus, 'LIKE')->condition('o.species', $species, 'LIKE')->execute()->fetchField();

--- a/includes/tripal_chado_datasets_mail.inc
+++ b/includes/tripal_chado_datasets_mail.inc
@@ -1,19 +1,26 @@
 <?php
 
 /**
- * drupal mail looks for a function that matches the first parameter _ mail
- * to build the message.
+ * Implement hook_mail
  *
- * @param $key
+ * @param $key - Valid keys are:
+ *  confirm_user_organism_submission
+ *  request_project_approved_email
+ *  register_project_submission_account
+ *  submit_dataset_email
+ *
  * @param $message
  * @param $params
  */
+
 function tripal_chado_datasets_mail($key, &$message, $params) {
   global $base_url, $base_path;
   $language = $message['language'];
 
+
   $name = isset($params['fullname']) ? $params['fullname'] : $params['cordinator_name'];
 
+  $site_name = variable_get('site_name', 'Drupal');
 
   $variables = [
     '!organism' => $params['genus'] . ' ' . $params['species'],
@@ -29,16 +36,25 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
     $filename_md5sum = $file->filename . ' & ' . $filename_md5sum;
   }
   switch ($key) {
-    //switching on $key lets you create variations of the email based on the $key parameter
-    case 'email_acknowledgement_touser':
-      $message['subject'] = t('Genome project submission inquiry at the i5k Workspace');
-      $message['body'][] = t('Thank you for your interest in submitting a genome project to the i5k Workspace! We will let you know within a few days whether your project request has been accepted, or whether we need to have more information from you before initiating your project.');
-      $message['body'][] = '<br><BR>Best, <br><bR>The i5k Workspace team';
+    //Sent by tripal_chado_datasets_request_project_submit.
+    //(Create chado organism request ackowledgement).
+
+    case 'confirm_user_organism_submission':
+
+      $subject = t('Genome project submission inquiry at ' . $site_name);
+      $message['subject'] = $subject;
+
+      $message['body']['preamble'] = t('Thank you for your interest in submitting a genome project to ' . $site_name . '!  Your request has been received, and a site administrator will contact you soon.');
+      $message['body']['signature'] = '<br/><br/>Best, <br/><br/>The ' . $site_name . 'team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
       break;
+
     case 'request_project_email':
+
+      //TODO this looks off to me... shouldnt it be !genus instead of $params['genus'] if we apass in teh $variables array into t()?
+
       $message['subject'] = t('New project request for "' . $params['genus'] . ' ' . $params['species'] . '"', $variables, ['langcode' => $language->language]);
-      //$variabless required even if not used to get $language in there
+      //$variables required even if not used to get $language in there
       //the email body is here, inside the $message array
       $message['body'][] = t($params['fullname'] . " requested for new project.<br><br><b>Below are the details:</b>", $variables, ['langcode' => $language->language]);
       $message['body'][] = '<br><b>Genus:</b> ' . $params['genus'] . '
@@ -47,26 +63,31 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
 <br><b>Common Name: </b>' . $params['common_name'] . '
 <br><b>Is the genome assembly already hosted at another genome portal, or is there another genome portal that would also be appropriate to host your dataset: </b>' . $params['genome_assembly_hosted'] . '
 <Br><b>Have you submitted the genome assembly to NCBI, or another INSDC member?: </b>' . $params['is_ncbi_submitted'] . '
-<br><b>Is this a re-assembly or new assembly of an existing i5k Workspace organism ? :</b> ' . $params['is_assembly'] . '
+<br><b>Is this a re-assembly or new assembly of an existing organism on the site? :</b> ' . $params['is_assembly'] . '
 <br><b>Were you involved in the generation of this genome assembly? : </b>' . $params['involved_in_generation'];
 
-      $message['body'][] = '<br><b>Briefly describe your plans for this genome project at the i5k Workspace: </b>' . $params['description'] . '  <bR><b>FullName: </b>' . $params['fullname'] . '
+      $message['body'][] = '<br><b>Briefly describe your plans for this genome project at ' . $site_name . ' </b>' . $params['description'] . '  <br><b>Full Name: </b>' . $params['fullname'] . '
 <br><b>Email:</b> ' . $params['email'];
       $message['body'][] = "<br><br>To view more click the <a href='" . $GLOBALS['base_url'] . "/admin/structure/datasets'>Admin</a> Link";
 
-      $message['body'][] = '<br><BR>Best,<br><bR>The i5k Workspace team';
+      $message['body'][] = '<br><BR>Best,<br><br>' . $site_name . ' team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
 
       break;
 
     case 'request_project_approved_email':
-      $message['subject'] = t('i5k Workspace Project Request Approved for "' . $params['genus'] . ' ' . $params['species'] . '"', $variables, ['langcode' => $language->language]);
+      //Let users know their project was approved.
+
+      $message['subject'] = t($site_name . ' Project Request Approved for "' . $params['genus'] . ' ' . $params['species'] . '"', $variables, ['langcode' => $language->language]);
       $message['body'][] = "Dear " . $params['fullname'] . ", <br><br>We have approved your project request for " . $params['genus'] . ' ' . $params['species'] . ".";
-      $message['body'][] = '<br>You can submit your datasets. Please visit <a href="https://i5k.nal.usda.gov/datasets/submit-a-dataset">https://i5k.nal.usda.gov/datasets/submit-a-dataset</a> to submit. For a general description of the submission process, please view <a href="https://i5k.nal.usda.gov/data-submission-overview">https://i5k.nal.usda.gov/data-submission-overview</a>. <Br><br>Best,<br><bR>The i5k Workspace team';
+      $message['body'][] = '<br>You can submit your datasets. Please visit <a href=' . $base_url . '"/datasets/submit-a-dataset"> ' . $base_url . '/datasets/submit-a-dataset</a> to submit.<Br><br>Best,<br><bR>' . $site_name . ' team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
       break;
 
     case 'register_project_submission_account':
+      //sent in tripal_chado_datasets_project_submission_account_submit
+      //request an account to submit data.
+
       $message['subject'] = t("" . $params['name'] . " registered for project or data submission account", $variables, ['langcode' => $language->language]);
       $message['body'][] = "Below are the user details<br><br> ";
       $message['body'][] = "<b>Name:</b> " . $params['name'] . "<br>";
@@ -74,21 +95,12 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
       $message['body'][] = "<b>Affiliation:</b> " . $params['affiliation'] . "<br>";
       $message['body'][] = "<b>Tell us about the data you want to submit or the project you want to start:</b> " . $params['content'] . "<br>";
       $message['body'][] = "<br>To create an user account go to <a href='" . $base_url . $base_path . "/admin/people'>" . $base_url . " /admin/people</a><br> Then click \"Add User\"<br><br>";
-      $message['body'][] = "<p>In the User creation page, manually enter the username, email and a random password twice.<br>
-  Check the options for:<br>
-  * i5k user<br>
-  * Notify user of new account <br><br>
-
-  Then click \"Create new account\"<br><br>
-
-  The user will never see the password we generate for them.  They will be emailed a one time link to reset their password.</p>";
-
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
       break;
 
     case 'submit_dataset_email':
       $message['subject'] = t('Submit dataset for ' . $params['organism'], $variables, ['langcode' => $language->language]);
-      $message['body'][] = t("Dear " . $params['name'] . ", <br><br> Thank you for submitting  a dataset for " . rtrim($params['organism']) . ". The i5k Workspace will review your submission and send you information on how to upload your dataset as soon as possible.", $variables, ['langcode' => $language->language]);
+      $message['body'][] = t("Dear " . $params['name'] . ", <br><br> Thank you for submitting  a dataset for " . rtrim($params['organism']) . ". We will review your submission and send you information on how to upload your dataset as soon as possible.", $variables, ['langcode' => $language->language]);
       $message['body'][] = "<h1>Submission details:</h1>";
       $message_body = "<b>Co-ordinator information:</b><br>";
       $message_body .= "Name: " . $params['name'] . "<br>";
@@ -96,45 +108,9 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
       $message_body .= "<b>Project Background:</b><br>";
       $message_body .= "Organism: " . $params['organism'] . "<br>";
       $message_body .= "Common name: " . $params['common_name'] . "<br>";
-
-      // $message_body .= "<h3>Genome assembly information:</h3>";
-      // $message_body .= "<b>Assembly Information:</b><br>";
-      // $message_body .= "Assembly name: " . $params['assembly_name'] . "<br>";
-      // $message_body .= "Assembly version: " . $params['assembly_version'] . "<br>";
-      // $message_body .= "NCBI/INSDC Genome assembly accession#: " . $params['assembly_accession'] . "<br>";
-      // $message_body .= "Analysis method: " . $params['assembly_method'] . "<br>";
-      // $message_body .= "Is the assembly published: " . $params['is_publish'] . "<br>";
-      // if (isset($params['is_publish']))
-      //   $message_body .= "IF " . $params['is_publish'] . ":" . $params['publish_field_data'] . "<br>";
-      // if (!empty($params['other_notes']))
-      //   $message_body .= "Other notes: " . $params['other_notes'] . "<br>";
-      // $message_body .= "<b>Data source information</b><br>";
-
-      // if (!empty($params['geo_location']))
-      //   $message_body .= "Geo Location: " . $params['geo_location'] . "<br>";
-
-      // if (!empty($params['tissues_located']))
-      //   $message_body .= "Tissues Located: " . $params['tissues_located'] . "<br>";
-
-      // if (!empty($params['gender'])) {
-      //   $message_body .= "Sex: " . $params['gender'] . "<br>";
-      //   if (isset($params['gender']) && $params['gender'] == 'NA')
-      //     $message_body .= "Other/NA: " . $params['other_gender'] . "<br>";
-      // }
-      // if (!empty($params['data_source_strain']))
-      //   $message_body .= "Strain: " . $params['data_source_strain'] . "<br>";
-
-      // if (!empty($params['data_source_notes']))
-      //   $message_body .= "Other notes: " . $params['data_source_notes'] . "<br>";
-      //   $message_body .= "Sequencing method: " . $params['data_source_seqplatform'] . "<br>";
-      // if (!empty($params['data_source_url']))
-      // $message_body .= "Data source URL: " . $params['data_source_url'] . "<br>";
-
-
       $message_body .= "Organism: " . $params['organism'] . "<br>";
       $message_body .= "Submitter Name: " . $params['name'] . "<br>";
       $message_body .= "Email Address: " . $params['email'] . "<br>";
-      // $message_body .= "Affiliation: " . $params['affiliation'] . "<br>";
       $message_body .= "Program: " . $params['program'] . "<br>";
       $message_body .= "Version: " . $params['version'] . "<br>";
       $message_body .= "Additional Information: " . $params['additional_info'] . "<br>";
@@ -153,7 +129,7 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
       if ($params['dataset_type'] == 'Assembly') {
         $message_body .= "<h3>Genome assembly information:</h3>";
         $message_body .= "Project description to display in your organism page: " . $params['description'] . "<br>";
-        $message_body .= "Will you manually curate this assembly using i5k workspace tools?: " . $params['is_curate_assembly'] . "<br>";
+        $message_body .= "Will you manually curate this assembly?: " . $params['is_curate_assembly'] . "<br>";
         if (isset($params['is_curate_assembly']) && $params['is_curate_assembly'] == 'Yes') {
           $message_body .= "Co-ordinator name: " . $params['manual_curation_name'] . "<bR>";
           $message_body .= "Co-ordinator Email: " . $params['manual_curation_email'] . "<bR>";
@@ -191,20 +167,11 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
         $message_body .= "Other notes: " . $params['additional_other_notes'] . "<br>";
       }
 
-
       if ($params['dataset_type'] == 'Gene prediction') {
 
         $message_body .= "<h3>Gene set information:</h3>";
         $message_body .= "Descriptive track name for JBrowse and Apollo: " . $params['gene_set_descriptive_track'] . "<br>";
         $message_body .= "Is this an Official Gene Set?: " . $params['is_ogs'] . "<br>";
-        // if (!empty($params['gene_set_is_publish'])) {
-        //   $message_body .= "Are the data published?: " . $params['gene_set_is_publish'] . "<br>";
-        //   if ($params['gene_set_is_publish'] == 'Yes') {
-        //     $message_body .= "If Yes: " . $params['gene_set_publish_field_data'] . "<br>";
-        //   } elseif ($params['gene_set_is_publish'] == 'No') {
-        //     $message_body .= "If No: " . $params['gene_set_publish_field_data'] . "<br>";
-        //   }
-        // }
       }
 
       if ($params['dataset_type'] == 'Mapped dataset') {
@@ -221,13 +188,10 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
         $message_body .= "Descriptive track name for JBrowse and Apollo: " . $params['mapped_dataset_descriptive_track'] . "<br>";
         $message_body .= "NCBI SRA accession number(s): " . $params['mapped_dataset_data_source_url'] . "<br>";
       }
-
-
       $message_body .= "<br><b>Filename & SHA512 </b>:";
       $message_body .= "<br>" . $filename_md5sum . "<br>";
       $message['body'][] = $message_body;
-      $message['body'][] = '<br><br>Best,<br><br>The i5k Workspace team';
-      $message['headers']['Bcc'] = 'i5k@ars.usda.gov';
+      $message['body'][] = '<br><br>Best,<br><br>' . $site_name . ' team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
       break;
   }

--- a/includes/tripal_chado_datasets_mail.inc
+++ b/includes/tripal_chado_datasets_mail.inc
@@ -35,6 +35,7 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
     $file = file_load($params['upload']);
     $filename_md5sum = $file->filename . ' & ' . $filename_md5sum;
   }
+
   switch ($key) {
     //Sent by tripal_chado_datasets_request_project_submit.
     //(Create chado organism request ackowledgement).
@@ -56,13 +57,13 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
       $message['subject'] = t('New project request for "' . $params['genus'] . ' ' . $params['species'] . '"', $variables, ['langcode' => $language->language]);
       //$variables required even if not used to get $language in there
       //the email body is here, inside the $message array
-      $message['body'][] = t($params['fullname'] . " requested for new project.<br><br><b>Below are the details:</b>", $variables, ['langcode' => $language->language]);
+      $message['body'][] = t("The user " . $params['fullname'] . " submitted a request for a new project.<br><br><b>Below are the details:</b>", $variables, ['langcode' => $language->language]);
       $message['body'][] = '<br><b>Genus:</b> ' . $params['genus'] . '
 <br><b>Species:</b> ' . $params['species'] . '
 <br><b>NCBI Taxid: </b>' . $params['ncbi_taxid'] . '
 <br><b>Common Name: </b>' . $params['common_name'] . '
 <br><b>Is the genome assembly already hosted at another genome portal, or is there another genome portal that would also be appropriate to host your dataset: </b>' . $params['genome_assembly_hosted'] . '
-<Br><b>Have you submitted the genome assembly to NCBI, or another INSDC member?: </b>' . $params['is_ncbi_submitted'] . '
+<br><b>Have you submitted the genome assembly to NCBI, or another INSDC member?: </b>' . $params['is_ncbi_submitted'] . '
 <br><b>Is this a re-assembly or new assembly of an existing organism on the site? :</b> ' . $params['is_assembly'] . '
 <br><b>Were you involved in the generation of this genome assembly? : </b>' . $params['involved_in_generation'];
 
@@ -70,7 +71,7 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
 <br><b>Email:</b> ' . $params['email'];
       $message['body'][] = "<br><br>To view more click the <a href='" . $GLOBALS['base_url'] . "/admin/structure/datasets'>Admin</a> Link";
 
-      $message['body'][] = '<br><BR>Best,<br><br>' . $site_name . ' team';
+      $message['body'][] = '<br><BR>Best, <br><br>' . $site_name . ' team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
 
       break;
@@ -80,7 +81,7 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
 
       $message['subject'] = t($site_name . ' Project Request Approved for "' . $params['genus'] . ' ' . $params['species'] . '"', $variables, ['langcode' => $language->language]);
       $message['body'][] = "Dear " . $params['fullname'] . ", <br><br>We have approved your project request for " . $params['genus'] . ' ' . $params['species'] . ".";
-      $message['body'][] = '<br>You can submit your datasets. Please visit <a href=' . $base_url . '"/datasets/submit-a-dataset"> ' . $base_url . '/datasets/submit-a-dataset</a> to submit.<Br><br>Best,<br><bR>' . $site_name . ' team';
+      $message['body'][] = '<br>You can submit your datasets. Please visit <a href=' . $base_url . '"/datasets/submit-a-dataset"> ' . $base_url . '/datasets/submit-a-dataset</a> to submit.<Br><br>Best, <br><bR>' . $site_name . ' team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
       break;
 
@@ -191,7 +192,7 @@ function tripal_chado_datasets_mail($key, &$message, $params) {
       $message_body .= "<br><b>Filename & SHA512 </b>:";
       $message_body .= "<br>" . $filename_md5sum . "<br>";
       $message['body'][] = $message_body;
-      $message['body'][] = '<br><br>Best,<br><br>' . $site_name . ' team';
+      $message['body'][] = '<br><br>Best, <br><br>' . $site_name . ' team';
       $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed';
       break;
   }

--- a/includes/tripal_chado_datasets_request_project.form.inc
+++ b/includes/tripal_chado_datasets_request_project.form.inc
@@ -182,7 +182,7 @@ function tripal_chado_datasets_request_project_submit($form, &$form_state) {
   $to_user = $values['email'];
 
   $from_address = variable_get('tripal_chado_datasets_FROM_ADDRESS');
-  $send_user = drupal_mail('tripal_chado_datasets', 'email_acknowledgement_touser', $to_user, language_default(), $data, $from_address, TRUE);
+  $send_user = drupal_mail('tripal_chado_datasets', 'confirm_user_organism_submission', $to_user, language_default(), $data, $from_address, TRUE);
   if (empty($send_user['result']) || ($send_user['result'] != 1)) {
     drupal_set_message(t('Failed to send e-mail to the submitted user.'));
   }

--- a/includes/tripal_chado_datasets_submission.form.inc
+++ b/includes/tripal_chado_datasets_submission.form.inc
@@ -6,9 +6,6 @@
 
 function tripal_chado_datasets_request_form($form, &$form_state) {
 
-
-
-
   //i5k specific code.
   $link = $GLOBALS['base_url'] . '/long-term-i5k-workspace-project-management';
   if (drupal_valid_path($link)) {
@@ -16,7 +13,6 @@ function tripal_chado_datasets_request_form($form, &$form_state) {
       '#markup' => t('<div id="text">Please note that this dataset will be visible to the public in the JBrowse genome browser. Contact us if this dataset needs to remain private. Refer to our <a href="' . $GLOBALS['base_url'] . '/data-management-policy">data management</a> and <a href="' . $GLOBALS['base_url'] . '/long-term-i5k-workspace-project-management">long-term management policy</a> documents for information about the data types that we store and our long-term data management policy.</div><br>'),
     ];
   }
-
 
   $form['data_provider'] = [
     '#type' => 'fieldset',


### PR DESCRIPTION
* we accomplish this largely by replacing i5k site name and url with the drupal `site_name` variable, and the global base_url variable.
* The original templates are in https://github.com/NAL-i5K/i5k_custom_tripal  although we may not need them any more.
* Before this can be merged, i'd like to generate the test emails locally.